### PR TITLE
refactor: clean up background worker; disable debug mode

### DIFF
--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -26,7 +26,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
     // initialise the background worker task
     await Workmanager().initialize(
       callbackDispatcher,
-      isInDebugMode: true,
+      isInDebugMode: false,
     );
 
     // trigger the background task to run every hour

--- a/lib/services/background_worker.dart
+++ b/lib/services/background_worker.dart
@@ -15,25 +15,27 @@ class BackgroundWorker {
 
   final Logger _logger = Logger();
 
+  final DatabaseService _databaseService;
+
+  BackgroundWorker({required DatabaseService databaseService})
+      : _databaseService = databaseService;
+
   Future<void> cleanUpCollectionDates() async {
     _logger.d('Clean up collection dates');
 
-    DatabaseService ds = DatabaseService();
-    await ds.updatePastCollectionDates();
+    await _databaseService.updatePastCollectionDates();
   }
 
-  Future<void> sendNotifications() async {
+  Future<void> sendNotifications(
+      NotificationService notificationService) async {
     _logger.d('Send notifications');
 
-    DatabaseService ds = DatabaseService();
-    NotificationService ns = NotificationService();
-
-    List<Bin> bins = await ds.listDueBins();
+    List<Bin> bins = await _databaseService.listDueBins();
     _logger.d('${bins.length} bins found with collections due');
 
     for (Bin b in bins) {
       // collection is due, send a notification
-      await ns.showNotification(
+      await notificationService.showNotification(
           title: 'Bin Reminder',
           body:
               '${b.name} is due ${DateHelper.getFormattedNextCollectionDate(b.collectionDate)}');
@@ -64,9 +66,10 @@ void callbackDispatcher() {
         if (dateLastRun.isBefore(DateHelper.getToday())) {
           l.d('Last run date is in the past, run background tasks');
           // scheduled job last ran yesterday.  Run it now
-          BackgroundWorker dw = BackgroundWorker();
+          BackgroundWorker dw =
+              BackgroundWorker(databaseService: DatabaseService());
           await dw.cleanUpCollectionDates();
-          await dw.sendNotifications();
+          await dw.sendNotifications(NotificationService());
         }
 
         prefs.setString(dateLastRunSharedPrefSettingName,

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -65,7 +65,8 @@ class NotificationService {
         iOS: DarwinNotificationDetails());
   }
 
-  Future showNotification({int id = 0, String? title, String? body}) async {
+  Future<void> showNotification(
+      {int id = 0, String? title, String? body}) async {
     await flutterLocalNotificationsPlugin.show(
         id, title, body, notificationDetails());
 


### PR DESCRIPTION
Refactored background worker to use dependency injection for database service and notification service. Also disabled debug mode for workmanager plugin to reduce notifications